### PR TITLE
Avoid multiple ssm network calls

### DIFF
--- a/lib/configClient.js
+++ b/lib/configClient.js
@@ -6,6 +6,7 @@ const DEFAULT_EXPIRY = 3 * 60 * 1000; // default expiry is 3 mins
 
 function loadConfigs (keys, expiryMs) {
   expiryMs = expiryMs || DEFAULT_EXPIRY; // defaults to 3 mins
+  let loadPromise;
 
   if (!keys || !Array.isArray(keys) || keys.length === 0) {
     throw new Error('you need to provide a non-empty array of config keys');
@@ -66,7 +67,12 @@ function loadConfigs (keys, expiryMs) {
     }
     
     try {
-      await reload();
+      if (!loadPromise) {
+        loadPromise = reload();
+      }
+
+      await loadPromise;
+
       return cache.items[key];
     } catch (err) {
       if (cache.items && cache.items.length > 0) {
@@ -82,6 +88,8 @@ function loadConfigs (keys, expiryMs) {
       console.error(err);
 
       throw err;
+    } finally {
+      loadPromise = null
     }
   };
   


### PR DESCRIPTION
Multiple requests to config vars while ssm load is not finished do not trigger multiple network calls.

Fixes #1